### PR TITLE
Prevent issue with destroy-time provisioner in TF0.13

### DIFF
--- a/helm-operator.tf
+++ b/helm-operator.tf
@@ -14,8 +14,8 @@ resource "null_resource" "crds" {
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
-    command = "kubectl delete -f - <<'EOF'\n${data.template_file.crds.rendered}\nEOF"
+    when    = destroy
+    command = "kubectl delete -f ${path.module}/templates/crds.yaml"
   }
 }
 


### PR DESCRIPTION
This PR is meant to resolve two issues related to destroy-time provisioners that occur when using Terraform 0.13.x.

```
Warning: Quoted keywords are deprecated

  on terraform-kubernetes-flux-0.0.3/helm-operator.tf line 17, in resource "null_resource" "crds":
  17:     when    = "destroy"

In this context, keywords are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted keywords are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this keyword to silence this warning.
```
```
Error: Invalid reference from destroy provisioner

  on terraform-kubernetes-flux-0.0.3/helm-operator.tf line 18, in resource "null_resource" "crds":
  18:     command = "kubectl delete -f - <<'EOF'\n${data.template_file.crds.rendered}\nEOF"

Destroy-time provisioners and their connection configurations may only
reference attributes of the related resource, via 'self', 'count.index', or
'each.key'.

References to other resources during the destroy phase can cause dependency
cycles and interact poorly with create_before_destroy.
```