### PR TITLE
Remove interpolation only expression

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -15,5 +15,5 @@ locals {
     app = "flux-memcached"
   }
 
-  config = "${file("${path.module}/templates/config.yaml")}"
+  config = file("${path.module}/templates/config.yaml")
 }


### PR DESCRIPTION
Removes the only interpolation only expression it had in the code. These expressions are going to be deprecated.